### PR TITLE
Update the Dissertation Approval Page

### DIFF
--- a/ucsddissertation.cls
+++ b/ucsddissertation.cls
@@ -164,24 +164,6 @@
 		and electronically.\par
 		\vspace{33em}
 		\centering
-%		\long\def\drawlines##1\par##2\enddrawlines{%
-%			\vskip.5in\hrule depth.8\p@
-%			\vskip3\p@\hfill
-%			\linelabel\par
-%			\ifx\relax##2\relax
-%			\else\drawlines##2\enddrawlines\fi}%
-%		\def\linelabel{\vphantom{Co-Chair}}%
-%		\expandafter\drawlines\@committee\enddrawlines
-%		\ifx\@cochair\@empty\else
-%			\def\linelabel{Co-Chair}%
-%			\expandafter\drawlines\@cochair\enddrawlines
-%		\fi
-%		\ifx\@chair\@empty\else
-%			\def\linelabel{Chair}%
-%			\expandafter\drawlines\@chair\enddrawlines
-%		\fi
-		
-%		\vskip\baselineskip
 		University of California San Diego\par
 		\@degreeyear
 	}

--- a/ucsddissertation.cls
+++ b/ucsddissertation.cls
@@ -153,7 +153,7 @@
 	\fi
 	\newpage
 	\csuse{phantomsection}%
-	\addcontentsline{toc}{chapter}{Signature Page}
+	\addcontentsline{toc}{chapter}{Dissertation Approval Page}
 	\Vspace\z@skip
 	\vfill
 	\noindent
@@ -161,26 +161,27 @@
 	\parbox{\linewidth-1in}{%
 		\noindent The Dissertation of \@author\ is approved, and it is
 		acceptable in quality and form for publication on microfilm
-		and electronically:\par
+		and electronically.\par
+		\vspace{33em}
 		\centering
-		\long\def\drawlines##1\par##2\enddrawlines{%
-			\vskip.5in\hrule depth.8\p@
-			\vskip3\p@\hfill
-			\linelabel\par
-			\ifx\relax##2\relax
-			\else\drawlines##2\enddrawlines\fi}%
-		\def\linelabel{\vphantom{Co-Chair}}%
-		\expandafter\drawlines\@committee\enddrawlines
-		\ifx\@cochair\@empty\else
-			\def\linelabel{Co-Chair}%
-			\expandafter\drawlines\@cochair\enddrawlines
-		\fi
-		\ifx\@chair\@empty\else
-			\def\linelabel{Chair}%
-			\expandafter\drawlines\@chair\enddrawlines
-		\fi
+%		\long\def\drawlines##1\par##2\enddrawlines{%
+%			\vskip.5in\hrule depth.8\p@
+%			\vskip3\p@\hfill
+%			\linelabel\par
+%			\ifx\relax##2\relax
+%			\else\drawlines##2\enddrawlines\fi}%
+%		\def\linelabel{\vphantom{Co-Chair}}%
+%		\expandafter\drawlines\@committee\enddrawlines
+%		\ifx\@cochair\@empty\else
+%			\def\linelabel{Co-Chair}%
+%			\expandafter\drawlines\@cochair\enddrawlines
+%		\fi
+%		\ifx\@chair\@empty\else
+%			\def\linelabel{Chair}%
+%			\expandafter\drawlines\@chair\enddrawlines
+%		\fi
 		
-		\vskip\baselineskip
+%		\vskip\baselineskip
 		University of California San Diego\par
 		\@degreeyear
 	}


### PR DESCRIPTION
Effective November 2020, faculty signatures are no longer collected on the dissertation/thesis approval page. Thus a few changes have been made to the (old) Signature page:
1. It's now named "Dissertation Approval Page"
2. The statement on the top of the page now ends with "." instead of ":"
3. The signature lines are removed, while the vertical space is kept.

For details, please refer to the 2020-2021 manual, page 12-15.
https://grad.ucsd.edu/_files/academics/BlueBook%202020-21%20updated%2011.06.20.pdf